### PR TITLE
feat: unify SaaS at app.digitaljamath.com

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,10 +5,12 @@
 # ============================================
 # General Settings
 # ============================================
-DOMAIN_NAME=localhost
+# DOMAIN_NAME drives email login-link generation in apps/shared/api.py.
+# In production this is the unified SaaS subdomain (app.digitaljamath.com).
+DOMAIN_NAME=app.digitaljamath.com
 DEBUG=True
 SECRET_KEY=dev-secret-key-change-in-prod
-ALLOWED_HOSTS=localhost,127.0.0.1,digitaljamath.com,*.digitaljamath.com
+ALLOWED_HOSTS=localhost,127.0.0.1,digitaljamath.com,www.digitaljamath.com,app.digitaljamath.com
 APP_VERSION=2.0.0
 
 # ============================================
@@ -65,5 +67,5 @@ RECAPTCHA_SECRET_KEY=your-recaptcha-secret-key
 # ============================================
 # Frontend URL (for email links)
 # ============================================
-# Use your domain in production
-FRONTEND_URL=http://localhost:5173
+# Use your unified app subdomain in production.
+FRONTEND_URL=https://app.digitaljamath.com

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -75,29 +75,33 @@ docker-compose -f docker-compose.prod.yml up -d
 ---
 
 ## 4. DNS Configuration (Cloudflare)
-Go to your Cloudflare Dashboard -> **DNS** and add these records:
+The platform runs on **two subdomains**:
+
+- `digitaljamath.com` (apex + `www`) — public marketing site
+- `app.digitaljamath.com` — unified SaaS entry point (admin login + member portal). Tenant context is resolved from the JWT, not from the subdomain.
+
+Add these records in Cloudflare DNS:
 
 | Type | Name | Content | Proxy |
 |------|------|---------|-------|
 | A | `@` | `<Your-Server-IP>` | **Proxied** (Orange Cloud) |
-| A | `*` | `<Your-Server-IP>` | **Proxied** (Orange Cloud) |
 | A | `www` | `<Your-Server-IP>` | **Proxied** (Orange Cloud) |
+| A | `app` | `<Your-Server-IP>` | **Proxied** (Orange Cloud) |
 
-### SSL/TLS Setting (Important!)
-Since our standard Docker setup uses **Nginx on Port 80**, you must set Cloudflare SSL to **Flexible**:
+> Per-jamath subdomains (`*.digitaljamath.com`) are no longer supported. Existing tenant subdomain bookmarks 301-redirect to `app.digitaljamath.com<path>`.
 
-1. Go to **SSL/TLS** -> **Overview**.
-2. Set mode to **Flexible** (Not Full/Strict).
-   *   *Full/Strict requires installing certs on the server, which is more complex.*
+### SSL/TLS Setting
+Run `certbot --nginx` on the origin for `app.digitaljamath.com`, `digitaljamath.com`, and `www.digitaljamath.com`, then set Cloudflare **SSL/TLS → Overview → Full (strict)**. Make sure the origin nginx server blocks listen on **both 80 and 443** without an HTTP→HTTPS redirect — otherwise Cloudflare in Flexible mode (port-80 fetch) will hit a redirect loop.
 
 ---
 
 ## 5. Verification
 Wait 1-2 minutes for DNS to propagate.
 
-1. **Frontend**: Visit `https://digitaljamath.com`.
-2. **Demo Portal**: Visit `https://demo.digitaljamath.com`.
-3. **Admin Panel**: Visit `https://digitaljamath.com/admin/`.
+1. **Marketing**: Visit `https://digitaljamath.com` → Next.js landing.
+2. **App (admin login)**: Visit `https://app.digitaljamath.com` → React SPA.
+3. **Admin Panel**: Visit `https://app.digitaljamath.com/admin/`.
+4. **Old subdomain redirect**: Visit `https://anything.digitaljamath.com/foo` → 301 to `https://app.digitaljamath.com/foo`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <img alt="Version" src="https://img.shields.io/badge/version-2.1.0-blue" />
   <a href="https://digitaljamath.com">🌐 digitaljamath.com</a>
   ·
-  <a href="https://demo.digitaljamath.com">▶ Live demo</a>
+  <a href="https://app.digitaljamath.com">▶ Live demo</a>
 </p>
 
 ---
@@ -54,12 +54,15 @@ We built this because:
 
 ## 🚀 Try it
 
-**Hosted demo (no install)** — [demo.digitaljamath.com](https://demo.digitaljamath.com)
+**Hosted demo (no install)** — [app.digitaljamath.com](https://app.digitaljamath.com)
 
 | Portal | Credentials |
 |--------|-------------|
 | Admin Dashboard | `demo@digitaljamath.com` / `password123` |
 | Member Portal | Phone `+919876543210`, OTP `123456` |
+
+> Self-hosting? Seed the same demo masjid + data with one command after install:
+> `docker compose exec web python manage.py setup_demo`
 
 **Run it yourself** — clone, run one command, you're online:
 
@@ -134,7 +137,7 @@ MIT. Use it, fork it, host it, sell support around it — just keep the license 
 ## 🔗 Links
 
 - 🌐 Website — [digitaljamath.com](https://digitaljamath.com)
-- ▶ Demo — [demo.digitaljamath.com](https://demo.digitaljamath.com)
+- ▶ Demo — [app.digitaljamath.com](https://app.digitaljamath.com)
 - 📦 Marketing site repo — [digitaljamath-website](https://github.com/digitaljamath/digitaljamath-website)
 - 📘 Deployment guide — [DEPLOYMENT.md](DEPLOYMENT.md)
 - 🤝 Contributing guide — [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/apps/shared/api.py
+++ b/apps/shared/api.py
@@ -52,9 +52,10 @@ class MosqueRegistrationView(generics.CreateAPIView):
 
         from .tasks import create_tenant_task
         import os
-        
+
         base_domain = os.environ.get('DOMAIN_NAME', 'localhost')
-        
+        protocol = 'https' if not settings.DEBUG else 'http'
+
         if settings.DEBUG or os.environ.get('CELERY_SYNC', 'false').lower() == 'true':
             try:
                 result = create_tenant_task(task_data)
@@ -62,7 +63,7 @@ class MosqueRegistrationView(generics.CreateAPIView):
                     "message": "Mosque created successfully.",
                     "status": "SUCCESS",
                     "task_id": "sync-task",
-                    "login_url": result.get('login_url', f"http://{base_domain}/auth/masjid/login")
+                    "login_url": result.get('login_url', f"{protocol}://{base_domain}/auth/masjid/login")
                 }, status=status.HTTP_201_CREATED)
             except Exception as e:
                 return Response({
@@ -75,7 +76,7 @@ class MosqueRegistrationView(generics.CreateAPIView):
                 "message": "Mosque creation started.",
                 "status": "pending",
                 "task_id": task_result.id,
-                "login_url": f"http://{base_domain}/auth/masjid/login"
+                "login_url": f"{protocol}://{base_domain}/auth/masjid/login"
             }, status=status.HTTP_202_ACCEPTED)
 
 _reg_otp_store = {}

--- a/frontend/src/layouts/DashboardLayout.tsx
+++ b/frontend/src/layouts/DashboardLayout.tsx
@@ -1,4 +1,4 @@
-import { getApiBaseUrl, getLandingPageUrl } from "@/lib/config";
+import { getApiBaseUrl } from "@/lib/config";
 import logo from "@/assets/logo.png";
 import { useRbac } from "@/context/RbacContext";
 import { useLocation, useNavigate, Link, Outlet } from "react-router-dom";
@@ -137,10 +137,10 @@ function DashboardInner() {
                 <div className="flex flex-col h-full">
                     {/* Logo */}
                     <div className="flex items-center justify-between h-20 px-8 border-b border-slate-200/50">
-                        <a href={getLandingPageUrl()} className="flex items-center justify-center font-extrabold text-xl gap-2 text-slate-900 tracking-tight hover:opacity-90 transition-opacity">
+                        <Link to="/dashboard" className="flex items-center justify-center font-extrabold text-xl gap-2 text-slate-900 tracking-tight hover:opacity-90 transition-opacity">
                             <img src={logo} alt="DigitalJamath Logo" className="h-8 w-8 drop-shadow-sm" />
                             <span>Digital<span className="text-transparent bg-clip-text bg-linear-to-r from-blue-600 to-indigo-600">Jamath</span></span>
-                        </a>
+                        </Link>
                         <Button
                             variant="ghost"
                             size="icon"

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -15,11 +15,17 @@ export function getApiBaseUrl(): string {
 }
 
 export function getLandingPageUrl(): string {
-    // If we're on the local Vite dev server, redirect back to the local Nginx proxy
+    // Local Vite dev server: send users to the local Nginx proxy.
     if (window.location.port === '5173' || window.location.port === '5174') {
         return 'http://127.0.0.1/'
     }
-    // In production, Nginx serves the root / as the Django landing page
+    // Production: the SPA lives on app.<root>; the marketing site lives on <root>.
+    // Strip the "app." prefix so "Go Back Home" lands on the marketing site.
+    const host = window.location.hostname
+    if (host.startsWith('app.')) {
+        return `${window.location.protocol}//${host.slice(4)}/`
+    }
+    // Same-origin fallback (e.g. SPA and marketing co-hosted on one domain).
     return '/'
 }
 


### PR DESCRIPTION
## Summary
- Document the new two-subdomain architecture: `digitaljamath.com` (marketing) + `app.digitaljamath.com` (unified SaaS).
- `.env.example` now reflects the production env var conventions (`DOMAIN_NAME`, `FRONTEND_URL`, `ALLOWED_HOSTS`).
- Small bug fix in `apps/shared/api.py`: `MosqueRegistrationView` login_url no longer hardcodes `http://` — uses `{protocol}` (https in prod) like `FindWorkspaceView` already does.
- `DEPLOYMENT.md` rewritten for the new shape (DNS records, SSL/TLS, verification URLs, note about old subdomain redirects).

## Why
Tenant context resolution is already JWT-based (`StaffMember.mosque` FK for admins, `member_<household_id>` synthetic users for portal members) — the per-jamath subdomain pattern is no longer needed. Consolidating onto `app.digitaljamath.com` simplifies onboarding (one URL), TLS management (one cert vs wildcard), and operational state.

The infra-side migration (nginx vhost for `app.`, Let's Encrypt cert, 301 redirect for `*.digitaljamath.com`, frontend image rebuilt + self-hosted) is already deployed on the new Hostinger origin and verified end-to-end.

## Test plan
- [ ] CI: lint + tests still pass
- [ ] Visit `https://digitaljamath.com/` → marketing landing
- [ ] Visit `https://app.digitaljamath.com/` → React SPA loads
- [ ] Visit `https://anything.digitaljamath.com/foo` → 301 to `https://app.digitaljamath.com/foo`
- [ ] `POST /api/register/` returns a `login_url` starting with `https://` (not `http://`) when `DEBUG=False`

🤖 Generated with [Claude Code](https://claude.com/claude-code)